### PR TITLE
Vendor @romanize/korean for internal use

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -46,3 +46,13 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+## Portions of this project are derived from `@romanize/korean`:
+
+MIT License
+
+Copyright (c) 2025 Kenneth Tang
+
+See /src/vendor/romanize/korean/LICENSE for full license text.

--- a/README.md
+++ b/README.md
@@ -294,7 +294,10 @@ This library draws on the capabilities of several existing libraries, many of wh
 - [**tnthai**](https://www.npmjs.com/package/tnthai) – used to segment Thai script into individual words before submitting them to the transliteration pipeline.
 - [**pythainlp**](https://github.com/PyThaiNLP/pythainlp) – external Python library used for Thai transliteration. **Note:** This is not a direct JavaScript dependency. It must be installed manually (alongside Python 3) in the runtime environment for `romanizeThai` to function.
 
-> Note: While this package was originally inspired by [**cyrillic-to-translit-js**](https://www.npmjs.com/package/cyrillic-to-translit-js), that codebase was not included as a dependency. Instead, its logic was replicated and extensively modified within this library to support additional Cyrillic-based languages.
+This project includes modified and vendored code from the following libraries:
+
+- [**cyrillic-to-translit-js**](https://www.npmjs.com/package/cyrillic-to-translit-js) by Aleksandr Filatov = MIT Licensed.  Logic adapted and restructured to support additional Cyrillic languages. Not used as a dependency; see Technical Notes.
+- [`@romanize/korean`](https://www.npmjs.com/package/@romanize/korean) by Kenneth Tang – MIT Licensed. Vendored and modified for structural compatibility. See `src/vendor/romanize/korean/LICENSE`.
 
 ## Technical Notes
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,6 @@ export default {
     transform: {
         "^.+\\.ts$": ["ts-jest", { useESM: true }],
     },
-    transformIgnorePatterns: ["node_modules/(?!(oktjs|@romanize/korean)/)"],
+    transformIgnorePatterns: ["node_modules/(?!(oktjs)/)"],
     extensionsToTreatAsEsm: [".ts"],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
     "name": "romanize-string",
-    "version": "0.1.0",
+    "version": "1.1.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "romanize-string",
-            "version": "0.1.0",
+            "version": "1.1.2",
             "license": "MIT",
             "dependencies": {
                 "@indic-transliteration/sanscript": "~1.3.1",
-                "@romanize/korean": "~0.1.3",
                 "arabic-transliterate": "~1.0.1",
                 "cantonese-romanisation": "~1.0.7",
                 "kuroshiro": "~1.2.0",
@@ -1016,12 +1015,6 @@
             "funding": {
                 "url": "https://opencollective.com/pkgr"
             }
-        },
-        "node_modules/@romanize/korean": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/@romanize/korean/-/korean-0.1.3.tgz",
-            "integrity": "sha512-Bfxze35S7ktKqm7ge78x3v7OW/TrbPV0gcvrHuTXUeeID7mGiWWUIH/fOS9lO25N1LY+n1S9xsixtxT9KggEYg==",
-            "license": "MIT"
         },
         "node_modules/@sinclair/typebox": {
             "version": "0.34.37",
@@ -4422,6 +4415,7 @@
             "version": "5.8.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
             "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+            "dev": true,
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "build:cjs": "tsc --outDir dist/cjs --module CommonJS",
         "build": "npm run build:esm && npm run build:cjs",
         "test": "node --experimental-vm-modules --experimental-specifier-resolution=node ./node_modules/jest/bin/jest.js --config jest.config.js",
-        "start": "npm run build && node dist/index.js",
+        "start": "npm run build && node dist/esm/index.js",
         "prepublishOnly": "npm run build"
     },
     "keywords": [
@@ -53,7 +53,6 @@
     "type": "module",
     "dependencies": {
         "@indic-transliteration/sanscript": "~1.3.1",
-        "@romanize/korean": "~0.1.3",
         "arabic-transliterate": "~1.0.1",
         "cantonese-romanisation": "~1.0.7",
         "kuroshiro": "~1.2.0",
@@ -65,9 +64,9 @@
     "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/node": "^22.15.33",
-        "typescript": "^5.8.3",
         "jest": "^30.0.3",
         "jest-environment-node": "^30.0.2",
-        "ts-jest": "^29.4.0"
+        "ts-jest": "^29.4.0",
+        "typescript": "^5.8.3"
     }
 }

--- a/src/transliterators/korean-romanization.ts
+++ b/src/transliterators/korean-romanization.ts
@@ -3,7 +3,7 @@ import {
     tokenize as koreanTokenize,
 } from "oktjs";
 
-import { romanize } from "../vendor/romanize/korean/src";
+import { romanize } from "../vendor/romanize/korean/src/index.js";
 
 export const romanizeKorean = (string: string): string => {
     // Normalize and tokenize string, omitting any extra white spaces

--- a/src/transliterators/korean-romanization.ts
+++ b/src/transliterators/korean-romanization.ts
@@ -3,7 +3,7 @@ import {
     tokenize as koreanTokenize,
 } from "oktjs";
 
-import { romanize } from "@romanize/korean";
+import { romanize } from "../vendor/romanize/korean/src";
 
 export const romanizeKorean = (string: string): string => {
     // Normalize and tokenize string, omitting any extra white spaces

--- a/src/vendor/romanize/korean/LICENSE
+++ b/src/vendor/romanize/korean/LICENSE
@@ -1,0 +1,7 @@
+Copyright © 2025 Kenneth Tang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/vendor/romanize/korean/src/constants/revised.ts
+++ b/src/vendor/romanize/korean/src/constants/revised.ts
@@ -1,4 +1,4 @@
-import { HangulJamo } from "../types/hangul";
+import { HangulJamo } from "../types/hangul.js";
 
 // https://www.korean.go.kr/front_eng/roman/roman_01.do
 // https://en.wikipedia.org/wiki/Revised_Romanization_of_Korean

--- a/src/vendor/romanize/korean/src/constants/revised.ts
+++ b/src/vendor/romanize/korean/src/constants/revised.ts
@@ -1,0 +1,337 @@
+import { HangulJamo } from "../types/hangul";
+
+// https://www.korean.go.kr/front_eng/roman/roman_01.do
+// https://en.wikipedia.org/wiki/Revised_Romanization_of_Korean
+export const REVISED_ROMANIZATION_OF_KOREAN: HangulJamo = {
+    // https://en.wikipedia.org/wiki/Revised_Romanization_of_Korean#Consonant_letters
+    ᄀ: {
+        base: "g",
+    },
+    ᄁ: {
+        base: "kk",
+    },
+    ᄂ: {
+        base: "n",
+    },
+    ᄃ: {
+        base: "d",
+    },
+    ᄄ: {
+        base: "tt",
+    },
+    ᄅ: {
+        base: "r",
+    },
+    ᄆ: {
+        base: "m",
+    },
+    ᄇ: {
+        base: "b",
+    },
+    ᄈ: {
+        base: "pp",
+    },
+    ᄉ: {
+        base: "s",
+    },
+    ᄊ: {
+        base: "ss",
+    },
+    ᄋ: {
+        base: "",
+    },
+    ᄌ: {
+        base: "j",
+    },
+    ᄍ: {
+        base: "jj",
+    },
+    ᄎ: {
+        base: "ch",
+    },
+    ᄏ: {
+        base: "k",
+    },
+    ᄐ: {
+        base: "t",
+    },
+    ᄑ: {
+        base: "p",
+    },
+    ᄒ: {
+        base: "h",
+    },
+    // https://en.wikipedia.org/wiki/Revised_Romanization_of_Korean#Vowel_letters
+    ᅡ: {
+        base: "a",
+    },
+    ᅢ: {
+        base: "ae",
+    },
+    ᅣ: {
+        base: "ya",
+    },
+    ᅤ: {
+        base: "yae",
+    },
+    ᅥ: {
+        base: "eo",
+    },
+    ᅦ: {
+        base: "e",
+    },
+    ᅧ: {
+        base: "yeo",
+    },
+    ᅨ: {
+        base: "ye",
+    },
+    ᅩ: {
+        base: "o",
+    },
+    ᅪ: {
+        base: "wa",
+    },
+    ᅫ: {
+        base: "wae",
+    },
+    ᅬ: {
+        base: "oe",
+    },
+    ᅭ: {
+        base: "yo",
+    },
+    ᅮ: {
+        base: "u",
+    },
+    ᅯ: {
+        base: "wo",
+    },
+    ᅰ: {
+        base: "we",
+    },
+    ᅱ: {
+        base: "wi",
+    },
+    ᅲ: {
+        base: "yu",
+    },
+    ᅳ: {
+        base: "eu",
+    },
+    ᅴ: {
+        base: "ui",
+    },
+    ᅵ: {
+        base: "i",
+    },
+    // https://en.wikipedia.org/wiki/Revised_Romanization_of_Korean#Consonant_letters
+    "": {
+        base: "",
+    },
+    ᆨ: {
+        base: "k",
+        next: {
+            ᄋ: "g",
+            ᄂ: "ngn",
+            ᄅ: "ngn",
+            ᄆ: "ngm",
+            ᄒ: "k", // 'kh,k'
+        },
+    },
+    ᆩ: {
+        base: "k",
+        next: {
+            ᄋ: "kk",
+        },
+    },
+    ᆪ: {
+        base: "k",
+        next: {
+            ᄋ: "ks",
+            ᄂ: "ngn",
+            ᄅ: "ngn",
+            ᄆ: "ngm",
+            ᄒ: "k", // 'kh,k'
+        },
+    },
+    ᆫ: {
+        base: "n",
+        next: {
+            ᄅ: "ll",
+        },
+    },
+    ᆬ: {
+        base: "n",
+        next: {
+            ᄋ: "nj",
+            ᄂ: "nn",
+            ᄅ: "nn",
+            ᄆ: "nm",
+            ᄒ: "ch", // 'th,t,ch'
+        },
+    },
+    ᆭ: {
+        base: "n",
+        next: {
+            ᄋ: "nh",
+            ᄀ: "nk",
+            ᄂ: "nn",
+            ᄅ: "nn",
+            ᄆ: "nm",
+            ᄇ: "nb",
+            ᄒ: "ch", // 'th,t,ch'
+        },
+    },
+    ᆮ: {
+        base: "t",
+        next: {
+            ᄋ: "j", // 'd,j'
+            ᄂ: "nn",
+            ᄅ: "nn",
+            ᄆ: "nm",
+            ᄒ: "ch", // 'th,t,ch'
+        },
+    },
+    ᆯ: {
+        base: "l",
+        next: {
+            ᄋ: "r",
+        },
+    },
+    ᆰ: {
+        base: "l",
+        next: {
+            ᄋ: "lg",
+        },
+    },
+    ᆱ: {
+        base: "l",
+        next: {
+            ᄋ: "lm",
+        },
+    },
+    ᆲ: {
+        base: "l",
+        next: {
+            ᄋ: "lb",
+        },
+    },
+    ᆳ: {
+        base: "l",
+        next: {
+            ᄋ: "ls",
+        },
+    },
+    ᆴ: {
+        base: "l",
+        next: {
+            ᄋ: "lt",
+        },
+    },
+    ᆵ: {
+        base: "l",
+        next: {
+            ᄋ: "lp",
+        },
+    },
+    ᆶ: {
+        base: "l",
+        next: {
+            ᄋ: "lh",
+        },
+    },
+    ᆷ: {
+        base: "m",
+    },
+    ᆸ: {
+        base: "p",
+        next: {
+            ᄋ: "b",
+            ᄂ: "mn",
+            ᄅ: "mn",
+            ᄆ: "mm",
+            ᄒ: "p", // 'ph,p'
+        },
+    },
+    ᆹ: {
+        base: "p",
+        next: {
+            ᄋ: "ps",
+        },
+    },
+    ᆺ: {
+        base: "t",
+        next: {
+            ᄋ: "s",
+            ᄂ: "nn",
+            ᄅ: "nn",
+            ᄆ: "nm",
+        },
+    },
+    ᆻ: {
+        base: "t",
+        next: {
+            ᄋ: "ss",
+        },
+    },
+    ᆼ: {
+        base: "ng",
+    },
+    ᆽ: {
+        base: "t",
+        next: {
+            ᄋ: "j",
+            ᄂ: "nn",
+            ᄅ: "nn",
+            ᄆ: "nm",
+            ᄒ: "ch", // 'th,t,ch'
+        },
+    },
+    ᆾ: {
+        base: "t",
+        next: {
+            ᄋ: "ch",
+            ᄂ: "nn",
+            ᄅ: "nn",
+            ᄆ: "nm",
+            ᄒ: "ch", // 'th,t,ch'
+        },
+    },
+    ᆿ: {
+        base: "k",
+    },
+    ᇀ: {
+        base: "t",
+        next: {
+            ᄂ: "nn",
+            ᄅ: "nn",
+            ᄆ: "nm",
+            ᄒ: "ch", // 'th,t,ch'
+        },
+    },
+    ᇁ: {
+        base: "p",
+    },
+    ᇂ: {
+        base: "t",
+        next: {
+            ᄋ: "h",
+            ᄀ: "k",
+            ᄁ: "kk",
+            ᄂ: "nn",
+            ᄃ: "t",
+            ᄄ: "tt",
+            ᄅ: "nn",
+            ᄆ: "nm",
+            ᄇ: "p",
+            ᄈ: "pp",
+            ᄉ: "s",
+            ᄊ: "ss",
+            ᄌ: "ch",
+            ᄍ: "jj",
+            ᄐ: "t",
+            ᄒ: "h",
+        },
+    },
+};

--- a/src/vendor/romanize/korean/src/constants/unicode.ts
+++ b/src/vendor/romanize/korean/src/constants/unicode.ts
@@ -1,0 +1,57 @@
+// https://en.wikipedia.org/wiki/Hangul
+export const HANGUL_BLOCKS: Record<
+  HangulBlock,
+  { start: number; end: number }
+> = {
+  // https://en.wikipedia.org/wiki/Hangul_Jamo
+  // https://unicode.org/charts/PDF/U1100.pdf
+  HANGUL_JAMO: {
+    start: 0x1100,
+    end: 0x11ff,
+  },
+  // https://en.wikipedia.org/wiki/Hangul_Compatibility_Jamo
+  // https://www.unicode.org/charts/PDF/U3130.pdf
+  HANGUL_COMPATIBILITY_JAMO: {
+    start: 0x3130,
+    end: 0x318f,
+  },
+  // https://en.wikipedia.org/wiki/Hangul_Jamo_Extended-A
+  // https://www.unicode.org/charts/PDF/UA960.pdf
+  HANGUL_JAMO_EXTENDED_A: {
+    start: 0xa960,
+    end: 0xa97f,
+  },
+  // https://en.wikipedia.org/wiki/Hangul_Jamo_Extended-B
+  // https://www.unicode.org/charts/PDF/UD7B0.pdf
+  HANGUL_JAMO_EXTENDED_B: {
+    start: 0xd7b0,
+    end: 0xd7ff,
+  },
+  // https://en.wikipedia.org/wiki/Hangul_Syllables
+  // https://www.unicode.org/charts/PDF/UAC00.pdf
+  HANGUL_SYLLABLES: {
+    start: 0xac00,
+    end: 0xd7af,
+  },
+  // https://en.wikipedia.org/wiki/CJK_Symbols_and_Punctuation
+  // https://www.unicode.org/charts/PDF/U3000.pdf
+  CJK_SYMBOLS_AND_PUNCTUATION: {
+    start: 0x3000,
+    end: 0x303f,
+  },
+  // https://en.wikipedia.org/wiki/Basic_Latin
+  // https://www.unicode.org/charts/PDF/U0000.pdf
+  BASIC_LATIN: {
+    start: 0x0000,
+    end: 0x007f,
+  },
+};
+
+export type HangulBlock =
+  | 'HANGUL_JAMO'
+  | 'HANGUL_COMPATIBILITY_JAMO'
+  | 'HANGUL_JAMO_EXTENDED_A'
+  | 'HANGUL_JAMO_EXTENDED_B'
+  | 'HANGUL_SYLLABLES'
+  | 'CJK_SYMBOLS_AND_PUNCTUATION'
+  | 'BASIC_LATIN';

--- a/src/vendor/romanize/korean/src/index.ts
+++ b/src/vendor/romanize/korean/src/index.ts
@@ -1,7 +1,7 @@
-import { REVISED_ROMANIZATION_OF_KOREAN } from "./constants/revised";
-import { HangulSyllable } from "./lib/decompose-hangul";
-import { HangulTree } from "./lib/is-hangul";
-import type { HangulJamo } from "./types/hangul";
+import { REVISED_ROMANIZATION_OF_KOREAN } from "./constants/revised.js";
+import { HangulSyllable } from "./lib/decompose-hangul.js";
+import { HangulTree } from "./lib/is-hangul.js";
+import type { HangulJamo } from "./types/hangul.js";
 
 const tree = new HangulTree();
 

--- a/src/vendor/romanize/korean/src/index.ts
+++ b/src/vendor/romanize/korean/src/index.ts
@@ -1,0 +1,61 @@
+import { REVISED_ROMANIZATION_OF_KOREAN } from "./constants/revised";
+import { HangulSyllable } from "./lib/decompose-hangul";
+import { HangulTree } from "./lib/is-hangul";
+import type { HangulJamo } from "./types/hangul";
+
+const tree = new HangulTree();
+
+function separate(hangul: string): string[] {
+    if (!tree.isHangul(hangul)) {
+        throw new Error("Not a Hangul string");
+    }
+    const chars = hangul.split("").reduce((list, char) => {
+        const result = tree.search(char.charCodeAt(0));
+        const block = result.length === 1 ? result[0].value : null;
+        switch (block) {
+            case "HANGUL_SYLLABLES":
+                const syllable = new HangulSyllable(char);
+                const { initial, medial, final } = syllable;
+                if (final !== "") {
+                    return list.concat([initial, medial, final]);
+                }
+                return list.concat([initial, medial]);
+            case null:
+            default:
+                return list.concat([char]);
+        }
+    }, [] as (keyof HangulJamo | string)[]);
+    return chars;
+}
+
+function convert(chars: string[], system: HangulJamo) {
+    let res = "";
+    for (let i = 0; i < chars.length; i++) {
+        if (chars[i] in system) {
+            const c = chars[i] as keyof HangulJamo;
+            if (
+                system[c].next &&
+                i + 1 < chars.length &&
+                chars[i + 1] in system
+            ) {
+                const nextC = chars[i + 1] as keyof HangulJamo;
+                if (nextC in system[c].next) {
+                    const nextInitial = nextC as keyof HangulJamo;
+                    res += system[c].next[nextInitial];
+                    i++;
+                    continue;
+                }
+            }
+            res += system[c].base;
+            continue;
+        }
+        res += chars[i];
+    }
+    return res;
+}
+
+export function romanize(hangul: string): string {
+    const chars = separate(hangul);
+
+    return convert(chars, REVISED_ROMANIZATION_OF_KOREAN);
+}

--- a/src/vendor/romanize/korean/src/lib/decompose-hangul.ts
+++ b/src/vendor/romanize/korean/src/lib/decompose-hangul.ts
@@ -1,0 +1,74 @@
+import type {
+  HangulInitials,
+  HangulMedials,
+  HangulFinals,
+} from '../types/hangul';
+
+export class HangulSyllable {
+  static SBase = 0xac00;
+  static LBase = 0x1100;
+  static VBase = 0x1161;
+  static TBase = 0x11a7;
+  static LCount = 19;
+  static VCount = 21;
+  static TCount = 28;
+  static NCount: number = HangulSyllable.VCount * HangulSyllable.TCount; // 588
+  static SCount: number = HangulSyllable.LCount * HangulSyllable.NCount; // 11,172
+
+  syllable: string;
+  public choseong: keyof HangulInitials;
+  public jungseong: keyof HangulMedials;
+  public jongseong: keyof HangulFinals;
+  constructor(syllable: string) {
+    if (
+      syllable.length !== 1 ||
+      syllable.charCodeAt(0) < 0xac00 ||
+      syllable.charCodeAt(0) > 0xd7a3
+    )
+      throw new Error(`Invalid Hangul Syllable "${syllable}"`);
+    this.syllable = syllable;
+    const { choseong, jungseong, jongseong } = this.map();
+    this.choseong = choseong;
+    this.jungseong = jungseong;
+    this.jongseong = jongseong;
+  }
+
+  // https://en.wikipedia.org/wiki/Korean_language_and_computers#Hangul_in_Unicode
+  // [(initial) × 588 + (medial) × 28 + (final)] + 44032
+  // See https://www.unicode.org/versions/Unicode13.0.0/ch03.pdf#G24646
+  // for official documentation on the arithmetic decomposition mapping of Hangul syllables
+  private map() {
+    const code = this.syllable.charCodeAt(0);
+    const SIndex = code - HangulSyllable.SBase;
+    const LIndex = Math.floor(SIndex / HangulSyllable.NCount);
+    const VIndex = Math.floor(
+      (SIndex % HangulSyllable.NCount) / HangulSyllable.TCount
+    );
+    const TIndex = SIndex % HangulSyllable.TCount;
+    const LPart = String.fromCharCode(
+      HangulSyllable.LBase + LIndex
+    ) as keyof HangulInitials;
+    const VPart = String.fromCharCode(
+      HangulSyllable.VBase + VIndex
+    ) as keyof HangulMedials;
+    const TPart =
+      TIndex === 0
+        ? ''
+        : (String.fromCharCode(
+            HangulSyllable.TBase + TIndex
+          ) as keyof HangulFinals);
+    return { choseong: LPart, jungseong: VPart, jongseong: TPart };
+  }
+
+  public get initial(): HangulSyllable['choseong'] {
+    return this.choseong;
+  }
+
+  public get medial(): HangulSyllable['jungseong'] {
+    return this.jungseong;
+  }
+
+  public get final(): HangulSyllable['jongseong'] {
+    return this.jongseong;
+  }
+}

--- a/src/vendor/romanize/korean/src/lib/decompose-hangul.ts
+++ b/src/vendor/romanize/korean/src/lib/decompose-hangul.ts
@@ -1,74 +1,74 @@
 import type {
-  HangulInitials,
-  HangulMedials,
-  HangulFinals,
-} from '../types/hangul';
+    HangulInitials,
+    HangulMedials,
+    HangulFinals,
+} from "../types/hangul.js";
 
 export class HangulSyllable {
-  static SBase = 0xac00;
-  static LBase = 0x1100;
-  static VBase = 0x1161;
-  static TBase = 0x11a7;
-  static LCount = 19;
-  static VCount = 21;
-  static TCount = 28;
-  static NCount: number = HangulSyllable.VCount * HangulSyllable.TCount; // 588
-  static SCount: number = HangulSyllable.LCount * HangulSyllable.NCount; // 11,172
+    static SBase = 0xac00;
+    static LBase = 0x1100;
+    static VBase = 0x1161;
+    static TBase = 0x11a7;
+    static LCount = 19;
+    static VCount = 21;
+    static TCount = 28;
+    static NCount: number = HangulSyllable.VCount * HangulSyllable.TCount; // 588
+    static SCount: number = HangulSyllable.LCount * HangulSyllable.NCount; // 11,172
 
-  syllable: string;
-  public choseong: keyof HangulInitials;
-  public jungseong: keyof HangulMedials;
-  public jongseong: keyof HangulFinals;
-  constructor(syllable: string) {
-    if (
-      syllable.length !== 1 ||
-      syllable.charCodeAt(0) < 0xac00 ||
-      syllable.charCodeAt(0) > 0xd7a3
-    )
-      throw new Error(`Invalid Hangul Syllable "${syllable}"`);
-    this.syllable = syllable;
-    const { choseong, jungseong, jongseong } = this.map();
-    this.choseong = choseong;
-    this.jungseong = jungseong;
-    this.jongseong = jongseong;
-  }
+    syllable: string;
+    public choseong: keyof HangulInitials;
+    public jungseong: keyof HangulMedials;
+    public jongseong: keyof HangulFinals;
+    constructor(syllable: string) {
+        if (
+            syllable.length !== 1 ||
+            syllable.charCodeAt(0) < 0xac00 ||
+            syllable.charCodeAt(0) > 0xd7a3
+        )
+            throw new Error(`Invalid Hangul Syllable "${syllable}"`);
+        this.syllable = syllable;
+        const { choseong, jungseong, jongseong } = this.map();
+        this.choseong = choseong;
+        this.jungseong = jungseong;
+        this.jongseong = jongseong;
+    }
 
-  // https://en.wikipedia.org/wiki/Korean_language_and_computers#Hangul_in_Unicode
-  // [(initial) × 588 + (medial) × 28 + (final)] + 44032
-  // See https://www.unicode.org/versions/Unicode13.0.0/ch03.pdf#G24646
-  // for official documentation on the arithmetic decomposition mapping of Hangul syllables
-  private map() {
-    const code = this.syllable.charCodeAt(0);
-    const SIndex = code - HangulSyllable.SBase;
-    const LIndex = Math.floor(SIndex / HangulSyllable.NCount);
-    const VIndex = Math.floor(
-      (SIndex % HangulSyllable.NCount) / HangulSyllable.TCount
-    );
-    const TIndex = SIndex % HangulSyllable.TCount;
-    const LPart = String.fromCharCode(
-      HangulSyllable.LBase + LIndex
-    ) as keyof HangulInitials;
-    const VPart = String.fromCharCode(
-      HangulSyllable.VBase + VIndex
-    ) as keyof HangulMedials;
-    const TPart =
-      TIndex === 0
-        ? ''
-        : (String.fromCharCode(
-            HangulSyllable.TBase + TIndex
-          ) as keyof HangulFinals);
-    return { choseong: LPart, jungseong: VPart, jongseong: TPart };
-  }
+    // https://en.wikipedia.org/wiki/Korean_language_and_computers#Hangul_in_Unicode
+    // [(initial) × 588 + (medial) × 28 + (final)] + 44032
+    // See https://www.unicode.org/versions/Unicode13.0.0/ch03.pdf#G24646
+    // for official documentation on the arithmetic decomposition mapping of Hangul syllables
+    private map() {
+        const code = this.syllable.charCodeAt(0);
+        const SIndex = code - HangulSyllable.SBase;
+        const LIndex = Math.floor(SIndex / HangulSyllable.NCount);
+        const VIndex = Math.floor(
+            (SIndex % HangulSyllable.NCount) / HangulSyllable.TCount
+        );
+        const TIndex = SIndex % HangulSyllable.TCount;
+        const LPart = String.fromCharCode(
+            HangulSyllable.LBase + LIndex
+        ) as keyof HangulInitials;
+        const VPart = String.fromCharCode(
+            HangulSyllable.VBase + VIndex
+        ) as keyof HangulMedials;
+        const TPart =
+            TIndex === 0
+                ? ""
+                : (String.fromCharCode(
+                      HangulSyllable.TBase + TIndex
+                  ) as keyof HangulFinals);
+        return { choseong: LPart, jungseong: VPart, jongseong: TPart };
+    }
 
-  public get initial(): HangulSyllable['choseong'] {
-    return this.choseong;
-  }
+    public get initial(): HangulSyllable["choseong"] {
+        return this.choseong;
+    }
 
-  public get medial(): HangulSyllable['jungseong'] {
-    return this.jungseong;
-  }
+    public get medial(): HangulSyllable["jungseong"] {
+        return this.jungseong;
+    }
 
-  public get final(): HangulSyllable['jongseong'] {
-    return this.jongseong;
-  }
+    public get final(): HangulSyllable["jongseong"] {
+        return this.jongseong;
+    }
 }

--- a/src/vendor/romanize/korean/src/lib/interval-tree.ts
+++ b/src/vendor/romanize/korean/src/lib/interval-tree.ts
@@ -1,0 +1,73 @@
+export class IntervalTree<T extends string> {
+  root: IntervalTreeNode<T> | null;
+  constructor(start?: number, end?: number, value?: T) {
+    this.root =
+      start && end && value ? new IntervalTreeNode(start, end, value) : null;
+  }
+
+  insert(start: number, end: number, value: T): IntervalTreeNode<T> {
+    const node = new IntervalTreeNode(start, end, value);
+    if (this.root === null) {
+      this.root = node;
+      return node;
+    }
+    this.root.insert(node);
+    return node;
+  }
+
+  search(num: number): IntervalTreeNode<T>[] {
+    if (this.root === null) {
+      return [];
+    }
+    return this.root.search(num);
+  }
+
+  exists(num: number): boolean {
+    return this.search(num).length > 0;
+  }
+}
+
+export class IntervalTreeNode<T extends String> {
+  start: number;
+  end: number;
+  value: T;
+  left: IntervalTreeNode<T> | null;
+  right: IntervalTreeNode<T> | null;
+  constructor(start: number, end: number, value: T) {
+    this.start = start;
+    this.end = end;
+    this.value = value;
+    this.left = null;
+    this.right = null;
+  }
+
+  insert(node: IntervalTreeNode<T>): void {
+    if (node.start < this.start) {
+      if (this.left === null) {
+        this.left = node;
+      } else {
+        this.left.insert(node);
+      }
+    } else {
+      if (this.right === null) {
+        this.right = node;
+      } else {
+        this.right.insert(node);
+      }
+    }
+  }
+
+  search(num: number): IntervalTreeNode<T>[] {
+    const result = [];
+    if (this.left !== null) {
+      result.push(...this.left.search(num));
+    }
+    if (this.start <= num && num <= this.end) {
+      result.push(this);
+    }
+    if (this.right !== null) {
+      result.push(...this.right.search(num));
+    }
+    return result;
+  }
+}

--- a/src/vendor/romanize/korean/src/lib/is-hangul.ts
+++ b/src/vendor/romanize/korean/src/lib/is-hangul.ts
@@ -1,0 +1,27 @@
+import { HANGUL_BLOCKS } from "../constants/unicode";
+import { IntervalTree } from "./interval-tree";
+
+export class HangulTree extends IntervalTree<keyof typeof HANGUL_BLOCKS> {
+  constructor() {
+    super();
+    Object.entries(HANGUL_BLOCKS).forEach(([block, { start, end }]) => {
+      super.insert(start, end, block as keyof typeof HANGUL_BLOCKS);
+    });
+  }
+
+  isHangulChar(char: string): boolean {
+    const code = char.charCodeAt(0);
+    return super.exists(code);
+  }
+
+  isHangul(str: string): boolean {
+    for (const char of str) {
+      if (!this.isHangulChar(char)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}
+
+export default HangulTree;

--- a/src/vendor/romanize/korean/src/lib/is-hangul.ts
+++ b/src/vendor/romanize/korean/src/lib/is-hangul.ts
@@ -1,27 +1,27 @@
-import { HANGUL_BLOCKS } from "../constants/unicode";
-import { IntervalTree } from "./interval-tree";
+import { HANGUL_BLOCKS } from "../constants/unicode.js";
+import { IntervalTree } from "./interval-tree.js";
 
 export class HangulTree extends IntervalTree<keyof typeof HANGUL_BLOCKS> {
-  constructor() {
-    super();
-    Object.entries(HANGUL_BLOCKS).forEach(([block, { start, end }]) => {
-      super.insert(start, end, block as keyof typeof HANGUL_BLOCKS);
-    });
-  }
-
-  isHangulChar(char: string): boolean {
-    const code = char.charCodeAt(0);
-    return super.exists(code);
-  }
-
-  isHangul(str: string): boolean {
-    for (const char of str) {
-      if (!this.isHangulChar(char)) {
-        return false;
-      }
+    constructor() {
+        super();
+        Object.entries(HANGUL_BLOCKS).forEach(([block, { start, end }]) => {
+            super.insert(start, end, block as keyof typeof HANGUL_BLOCKS);
+        });
     }
-    return true;
-  }
+
+    isHangulChar(char: string): boolean {
+        const code = char.charCodeAt(0);
+        return super.exists(code);
+    }
+
+    isHangul(str: string): boolean {
+        for (const char of str) {
+            if (!this.isHangulChar(char)) {
+                return false;
+            }
+        }
+        return true;
+    }
 }
 
 export default HangulTree;

--- a/src/vendor/romanize/korean/src/types/hangul.ts
+++ b/src/vendor/romanize/korean/src/types/hangul.ts
@@ -1,0 +1,87 @@
+// See https://en.wikipedia.org/wiki/Korean_language_and_computers#Hangul_syllables_block
+// for list of all Unicode characters for initials, medials, and finals in Hangul
+export interface HangulInitials {
+  ᄀ: HangulChar;
+  ᄁ: HangulChar;
+  ᄂ: HangulChar;
+  ᄃ: HangulChar;
+  ᄄ: HangulChar;
+  ᄅ: HangulChar;
+  ᄆ: HangulChar;
+  ᄇ: HangulChar;
+  ᄈ: HangulChar;
+  ᄉ: HangulChar;
+  ᄊ: HangulChar;
+  ᄋ: HangulChar;
+  ᄌ: HangulChar;
+  ᄍ: HangulChar;
+  ᄎ: HangulChar;
+  ᄏ: HangulChar;
+  ᄐ: HangulChar;
+  ᄑ: HangulChar;
+  ᄒ: HangulChar;
+}
+
+export interface HangulMedials {
+  ᅡ: HangulChar;
+  ᅢ: HangulChar;
+  ᅣ: HangulChar;
+  ᅤ: HangulChar;
+  ᅥ: HangulChar;
+  ᅦ: HangulChar;
+  ᅧ: HangulChar;
+  ᅨ: HangulChar;
+  ᅩ: HangulChar;
+  ᅪ: HangulChar;
+  ᅫ: HangulChar;
+  ᅬ: HangulChar;
+  ᅭ: HangulChar;
+  ᅮ: HangulChar;
+  ᅯ: HangulChar;
+  ᅰ: HangulChar;
+  ᅱ: HangulChar;
+  ᅲ: HangulChar;
+  ᅳ: HangulChar;
+  ᅴ: HangulChar;
+  ᅵ: HangulChar;
+}
+
+export interface HangulFinals {
+  '': HangulChar;
+  ᆨ: HangulChar;
+  ᆩ: HangulChar;
+  ᆪ: HangulChar;
+  ᆫ: HangulChar;
+  ᆬ: HangulChar;
+  ᆭ: HangulChar;
+  ᆮ: HangulChar;
+  ᆯ: HangulChar;
+  ᆰ: HangulChar;
+  ᆱ: HangulChar;
+  ᆲ: HangulChar;
+  ᆳ: HangulChar;
+  ᆴ: HangulChar;
+  ᆵ: HangulChar;
+  ᆶ: HangulChar;
+  ᆷ: HangulChar;
+  ᆸ: HangulChar;
+  ᆹ: HangulChar;
+  ᆺ: HangulChar;
+  ᆻ: HangulChar;
+  ᆼ: HangulChar;
+  ᆽ: HangulChar;
+  ᆾ: HangulChar;
+  ᆿ: HangulChar;
+  ᇀ: HangulChar;
+  ᇁ: HangulChar;
+  ᇂ: HangulChar;
+}
+
+export interface HangulChar {
+  base: string;
+  next?: Partial<Record<keyof HangulJamo, string>>;
+}
+
+export type HangulJamo = HangulInitials & HangulMedials & HangulFinals;
+
+export type Hangul = keyof HangulJamo;

--- a/test/korean-romanization/ko.test.ts
+++ b/test/korean-romanization/ko.test.ts
@@ -54,13 +54,13 @@ describe("romanizeHangul1", () => {
         expect(romanize("버")).toEqual("beo");
         expect(
             romanize(`훌쩍 커버렸어
-        함께한 기억처럼
-        널 보는 내 마음은
-        어느새 여름 지나 가을`)
+            함께한 기억처럼
+            널 보는 내 마음은
+            어느새 여름 지나 가을`)
         ).toEqual(`huljjeok keobeoryeosseo
-    hamkkehan gieokcheoreom
-    neol boneun nae maeumeun
-    eoneusae yeoreum jina gaeul`);
+            hamkkehan gieokcheoreom
+            neol boneun nae maeumeun
+            eoneusae yeoreum jina gaeul`);
     });
 });
 

--- a/test/korean-romanization/ko.test.ts
+++ b/test/korean-romanization/ko.test.ts
@@ -1,4 +1,6 @@
 import { romanizeKorean } from "../../src/transliterators/korean-romanization";
+import { HangulSyllable } from "../../src/vendor/romanize/korean/src/lib/decompose-hangul";
+import { romanize } from "../../src/vendor/romanize/korean/src";
 
 describe("romanizeKorean", () => {
     it("should correctly romanize basic Hangul syllables", () => {
@@ -32,5 +34,49 @@ describe("romanizeKorean", () => {
 
     it("should handle mixed Korean and non-Korean input", () => {
         expect(romanizeKorean("안녕 Hello")).toBe("annyeong Hello");
+    });
+});
+
+describe("HangulSyllable", () => {
+    it("should decompose 훌 into choseong, jungseong, and jongseong", () => {
+        const hangul = new HangulSyllable("훌");
+        expect([hangul.initial, hangul.medial, hangul.final]).toEqual([
+            "ᄒ",
+            "ᅮ",
+            "ᆯ",
+        ]);
+    });
+});
+
+describe("romanizeHangul1", () => {
+    it("should correctly romanize common syllables and sentences", () => {
+        expect(romanize("훌")).toEqual("hul");
+        expect(romanize("버")).toEqual("beo");
+        expect(
+            romanize(`훌쩍 커버렸어
+        함께한 기억처럼
+        널 보는 내 마음은
+        어느새 여름 지나 가을`)
+        ).toEqual(`huljjeok keobeoryeosseo
+    hamkkehan gieokcheoreom
+    neol boneun nae maeumeun
+    eoneusae yeoreum jina gaeul`);
+    });
+});
+
+describe("romanizeHangul2", () => {
+    it("should match expected romanizations for multiple words and phrases", () => {
+        const tests = {
+            안녕하세요: "annyeonghaseyo",
+            안녕: "annyeong",
+            안녕하십니까: "annyeonghasimnikka",
+            좋고: "joko",
+            놓다: "nota",
+            잡혀: "japyeo",
+            낳지: "nachi",
+        };
+        for (const [hangul, romanized] of Object.entries(tests)) {
+            expect(romanize(hangul)).toEqual(romanized);
+        }
     });
 });

--- a/test/korean-romanization/ko.test.ts
+++ b/test/korean-romanization/ko.test.ts
@@ -1,6 +1,6 @@
-import { romanizeKorean } from "../../src/transliterators/korean-romanization";
-import { HangulSyllable } from "../../src/vendor/romanize/korean/src/lib/decompose-hangul";
-import { romanize } from "../../src/vendor/romanize/korean/src";
+import { romanizeKorean } from "../../src/transliterators/korean-romanization.js";
+import { HangulSyllable } from "../../src/vendor/romanize/korean/src/lib/decompose-hangul.js";
+import { romanize } from "../../src/vendor/romanize/korean/src/index.js";
 
 describe("romanizeKorean", () => {
     it("should correctly romanize basic Hangul syllables", () => {


### PR DESCRIPTION
- Incorporate @romanize/korean as vendored code under src/vendor/, with modifications for integration.
- Strip out support for unused transliteration systems.
- Incorporate tests into current testing flow