### PR TITLE
fix: cantoneseRomanization omitting punctuation and non-Chinese characters

### DIFF
--- a/src/transliterators/cantonese-romanization.ts
+++ b/src/transliterators/cantonese-romanization.ts
@@ -1,10 +1,38 @@
 import { getRoman } from "cantonese-romanisation";
+const hanziRegex = /[\p{Script=Han}]/u;
 
 export const romanizeCantonese = (input: string) => {
-    const transliteration = getRoman(input)
-        .map((options) => options[0])
-        .join(" ")
-        .replace(/\s+/g, " ");
+    let transliteration = "";
+    let buffer = "";
+    let lastWasHanzi = null;
 
-    return transliteration;
+    for (const char of input) {
+        const isHanzi = hanziRegex.test(char);
+
+        if (lastWasHanzi === null) {
+            lastWasHanzi = isHanzi;
+            buffer = char;
+        } else if (isHanzi === lastWasHanzi) {
+            buffer += char;
+        } else {
+            transliteration += lastWasHanzi
+                ? getRoman(buffer)
+                      .map((options) => options[0])
+                      .join(" ")
+                : buffer;
+            buffer = char;
+            lastWasHanzi = isHanzi;
+        }
+    }
+
+    // Handle final buffer
+    if (buffer) {
+        transliteration += lastWasHanzi
+            ? getRoman(buffer)
+                  .map((options) => options[0])
+                  .join(" ")
+            : buffer;
+    }
+
+    return transliteration.replace(/\s+/g, " ").trim();
 };

--- a/test/cantonese-romanization/yue.test.ts
+++ b/test/cantonese-romanization/yue.test.ts
@@ -13,7 +13,7 @@ describe("romanizeCantonese", () => {
         expect(romanizeCantonese("")).toBe("");
     });
 
-    it("should ignore non-Chinese characters", () => {
-        expect(romanizeCantonese("123 abc")).toBe(" ");
+    it("should leave non-Chinese characters untransliterated", () => {
+        expect(romanizeCantonese("123 abc")).toBe("123 abc");
     });
 });


### PR DESCRIPTION
- Restores punctuation and other non-Hanzi characters to Cantonese transliterations.