### PR TITLE
Fix extra spaces appearing before punctuation.

### DIFF
--- a/src/transliterators/japanese-romanization.ts
+++ b/src/transliterators/japanese-romanization.ts
@@ -11,7 +11,8 @@ export const romanizeJapanese = async (input: string) => {
     });
     const standardizedTransliteration = transliteration
         .replace(/\b(\w+)\s+(ta|te|nai|masu|desu|da)\b/g, "$1$2") // Join common verb splits like "megumare ta" -> "megumareta".
-        .replace(/\s+/g, " ");
+        .replace(/\s+/g, " ")
+        .replace(/\s+([.,!?！？。、])/g, "$1");
 
     return standardizedTransliteration;
 };

--- a/src/transliterators/korean-romanization.ts
+++ b/src/transliterators/korean-romanization.ts
@@ -27,6 +27,10 @@ export const romanizeKorean = (string: string): string => {
         []
     );
 
-    // Join the processed array of tokens into a single string, omitting any additional extra white spaces that may have crept in during the process.
-    return josaJoined.join(" ").replace(/\s+/g, " ");
+    // Join the processed array of tokens into a single string, omitting any additional extra white spaces
+    // that may have crept in during the process and removing white spaces before punctuation.
+    return josaJoined
+        .join(" ")
+        .replace(/\s+/g, " ")
+        .replace(/\s+([.,!?！？。、])/g, "$1");
 };

--- a/src/transliterators/mandarin-romanization.ts
+++ b/src/transliterators/mandarin-romanization.ts
@@ -11,6 +11,14 @@ export const romanizeMandarin = (input: string, omitTones?: boolean) => {
     }
     const transliteration = pinyin(input, {
         toneType: omitTones ? "none" : undefined,
-    }).replace(/\s+/g, " ");
+    })
+        .replace(/(\S)\s+([，。！？、])/gu, "$1$2") // Remove extra spaces before punctuation
+        .replace(/\s+/g, " ")
+        // Replace full-width punctuation with standard ASCII punctuation.
+        .replace(/[，]/g, ",")
+        .replace(/[。]/g, ".")
+        .replace(/[？]/g, "?")
+        .replace(/[！]/g, "!")
+        .trim();
     return transliteration;
 };

--- a/src/transliterators/thai-romanization.ts
+++ b/src/transliterators/thai-romanization.ts
@@ -36,7 +36,9 @@ export const romanizeThai = (input: string) => {
             );
         }
 
-        return result.stdout.trim();
+        return result.stdout
+            .replace(/\b(\w{1,10})\s*\/\s*(\w{1,10})\b/g, "$1/$2") // Remove spaces around polite suffix separators
+            .trim();
     } catch (err) {
         console.error("Thai transliteration failed.");
         console.error(err);


### PR DESCRIPTION
- Remove extra spaces before common punctuation marks in Japanese, Mandarin, and Korean
- Convert full-width punctuation in Mandarin transliterations to their standard ASCII counterparts to eliminate extra visual width
- Remove spaces before and after polite suffix separators in Thai transliterations