### PR TITLE
Fix missing spaces after punctuation in Arabic transliterations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "romanize-string",
-    "version": "1.2.4",
+    "version": "1.2.5",
     "description": "A fully typed, general-purpose utility for unidirectional string transliteration (non-Latin script => Latin script).",
     "main": "dist/index.js",
     "types": "dist/types/index.d.ts",

--- a/src/transliterators/arabic-romanization.ts
+++ b/src/transliterators/arabic-romanization.ts
@@ -13,7 +13,10 @@ export const romanizeArabic = (input: string): string => {
         "Arabic"
     );
 
-    return transliterated.replace(/-\s*/g, "-").replace(/\bal-lāh\b/, "Allāh");
+    return transliterated
+        .replace(/-\s*/g, "-") // remove spaces after hyphens
+        .replace(/\bal-lāh\b/, "Allāh") // replace al-lāh with Allāh
+        .replace(/([,؛:])([^\s]|$)/g, "$1 $2"); // add a space after commas, semicolons, and colons
 };
 
 // Because Persian (Farsi) and Urdu omit short vowels, there is no existing library capable of transliterating them,


### PR DESCRIPTION
- Add a replace call to add spaces after commas, semicolons, and colons whenever missing in Arabic transliterations
- Advance version number