### PR TITLE
Fix GitHub actions

### DIFF
--- a/.changeset/quick-bugs-sing.md
+++ b/.changeset/quick-bugs-sing.md
@@ -1,0 +1,6 @@
+---
+"romanize-string": patch
+"@romanize-string/thai-romanizer": patch
+---
+
+Updates docs to integrate changelog

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,13 +1,39 @@
 name: Build Cross-Platform Binaries
 
 on:
-  push:
-    tags:
-      - '@romanize-string/thai-romanizer@*' # only run when you push a version tag like v1.0.0
+  release:
+    types: [published]
   workflow_dispatch:
 
 jobs:
+  prepare:
+    name: Determine release tag
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.settag.outputs.release_tag }}
+    steps:
+      - name: Resolve tag
+        id: settag
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const eventName = context.eventName;
+            let tag;
+            if (eventName === 'release') {
+              tag = context.payload.release.tag_name;
+            } else {
+              const { data } = await github.rest.repos.getLatestRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+              tag = data.tag_name;
+            }
+            core.setOutput('release_tag', tag);
+
   build:
+    needs: prepare
+    # Only build for thai-romanizer releases
+    if: startsWith(needs.prepare.outputs.release_tag, '@romanize-string/thai-romanizer@')
     strategy:
       fail-fast: false
       matrix:
@@ -40,8 +66,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Checkout code
+      - name: Checkout code at release tag
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.prepare.outputs.release_tag }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -68,11 +97,12 @@ jobs:
           if-no-files-found: error
 
   release:
-    name: Create GitHub Release
-    needs: build
+    name: Attach binaries to Release
+    needs: [build, prepare]
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    if: startsWith(needs.prepare.outputs.release_tag, '@romanize-string/thai-romanizer@')
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -88,10 +118,10 @@ jobs:
           done
           echo "Generated checksums:" && find . -name '*.sha256' -maxdepth 2 -print
 
-      - name: Create / update release and upload assets
+      - name: Upload assets to release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ needs.prepare.outputs.release_tag }}
           files: |
             artifacts/*/*
             artifacts/*/*.sha256

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -86,8 +86,12 @@ jobs:
       - name: Build binary
         working-directory: packages/thai-romanizer/python
         run: |
-          pyinstaller --name "${{matrix.asset_name}}${{ matrix.ext }}" thai-romanization.spec
+          # Build from spec (cannot pass --name with a .spec file)
+          pyinstaller thai-romanization.spec
           ls -la dist
+          # Rename the produced binary to the matrix-provided asset name
+          BUILT_FILE=$(find dist -maxdepth 1 -type f -print -quit)
+          mv "$BUILT_FILE" "dist/${{ matrix.asset_name }}${{ matrix.ext }}"
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -83,15 +83,25 @@ jobs:
           python -m pip install --upgrade pip
           pip install pyinstaller pythainlp
 
-      - name: Build binary
+      - name: Build binary from spec
+        working-directory: packages/thai-romanizer/python
+        run: |
+          pyinstaller thai-romanization.spec
+
+      - name: Rename artifact (Windows)
+        if: runner.os == 'Windows'
+        working-directory: packages/thai-romanizer/python
+        run: |
+          Write-Host "Contents of dist after build:"; Get-ChildItem dist
+          $file = Get-ChildItem -File dist | Select-Object -First 1
+          Move-Item -Force $file.FullName "dist\${{ matrix.asset_name }}${{ matrix.ext }}"
+
+      - name: Rename artifact (Non-Windows)
+        if: runner.os != 'Windows'
         shell: bash
         working-directory: packages/thai-romanizer/python
         run: |
-          # Build from spec (cannot pass --name with a .spec file)
-          pyinstaller thai-romanization.spec
-          echo "Contents of dist after build:"
-          ls -la dist
-          # Rename the produced binary to the matrix-provided asset name (portable)
+          echo "Contents of dist after build:"; ls -la dist
           BUILT_FILE=$(ls -1 dist | head -n 1)
           mv "dist/$BUILT_FILE" "dist/${{ matrix.asset_name }}${{ matrix.ext }}"
 

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -44,7 +44,7 @@ jobs:
             asset_name: thai-linux-x64
             ext: ''
           # Linux arm64 (ARM runners)
-          - os: ubuntu-22.04-arm64
+          - os: ubuntu-24.04-arm64
             pyver: '3.11'
             asset_name: thai-linux-arm64
             ext: ''
@@ -84,14 +84,16 @@ jobs:
           pip install pyinstaller pythainlp
 
       - name: Build binary
+        shell: bash
         working-directory: packages/thai-romanizer/python
         run: |
           # Build from spec (cannot pass --name with a .spec file)
           pyinstaller thai-romanization.spec
+          echo "Contents of dist after build:"
           ls -la dist
-          # Rename the produced binary to the matrix-provided asset name
-          BUILT_FILE=$(find dist -maxdepth 1 -type f -print -quit)
-          mv "$BUILT_FILE" "dist/${{ matrix.asset_name }}${{ matrix.ext }}"
+          # Rename the produced binary to the matrix-provided asset name (portable)
+          BUILT_FILE=$(ls -1 dist | head -n 1)
+          mv "dist/$BUILT_FILE" "dist/${{ matrix.asset_name }}${{ matrix.ext }}"
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,6 +1,9 @@
 name: Build Cross-Platform Binaries
 
 on:
+  workflow_run:
+    workflows: ["Tag & Release (after Changesets version)"]
+    types: [completed]
   release:
     types: [published]
   workflow_dispatch:
@@ -10,30 +13,51 @@ jobs:
     name: Determine release tag
     runs-on: ubuntu-latest
     outputs:
-      release_tag: ${{ steps.settag.outputs.release_tag }}
+      release_tag: ${{ steps.pick.outputs.release_tag }}
     steps:
-      - name: Resolve tag
-        id: settag
+      - name: Pick latest thai-romanizer release tag
+        id: pick
         uses: actions/github-script@v7
         with:
           script: |
-            const eventName = context.eventName;
-            let tag;
-            if (eventName === 'release') {
-              tag = context.payload.release.tag_name;
-            } else {
-              const { data } = await github.rest.repos.getLatestRelease({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-              });
-              tag = data.tag_name;
+            const { owner, repo } = context.repo;
+            const PREFIX = '@romanize-string/thai-romanizer@';
+
+            if (context.eventName === 'release') {
+              const tag = context.payload?.release?.tag_name || '';
+              core.setOutput('release_tag', tag);
+              return;
             }
-            core.setOutput('release_tag', tag);
+
+            if (context.eventName === 'workflow_run') {
+              const sha = context.payload?.workflow_run?.head_sha;
+              if (!sha) {
+                core.setOutput('release_tag', '');
+                return;
+              }
+              // Find tags that start with our package prefix and point to this SHA
+              const { data: refs } = await github.rest.git.listMatchingRefs({
+                owner,
+                repo,
+                ref: `tags/${PREFIX}`,
+              });
+              const match = refs.find(r => (r.object?.sha === sha));
+              const tag = match ? match.ref.replace('refs/tags/', '') : '';
+              core.setOutput('release_tag', tag);
+              return;
+            }
+
+            // Fallback for manual runs: use the most recent release for the package
+            const { data: releases } = await github.rest.repos.listReleases({ owner, repo, per_page: 50 });
+            const latest = releases.find(r => (r.tag_name || '').startsWith(PREFIX));
+            core.setOutput('release_tag', latest ? latest.tag_name : '');
 
   build:
     needs: prepare
-    # Only build for thai-romanizer releases
-    if: startsWith(needs.prepare.outputs.release_tag, '@romanize-string/thai-romanizer@')
+    # Only build when we have a thai-romanizer release tag AND either:
+    # - manual run, or
+    # - the upstream workflow completed successfully
+    if: needs.prepare.outputs.release_tag != '' && startsWith(needs.prepare.outputs.release_tag, '@romanize-string/thai-romanizer@') && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' || github.event_name == 'release')
     strategy:
       fail-fast: false
       matrix:
@@ -43,7 +67,7 @@ jobs:
             pyver: '3.11'
             asset_name: thai-linux-x64
             ext: ''
-          # Linux arm64 (ARM runners)
+          # Linux arm64 (QEMU)
           - os: ubuntu-latest
             pyver: '3.11'
             asset_name: thai-linux-arm64
@@ -126,13 +150,6 @@ jobs:
             ls -la dist
             f=$(ls -1 dist | head -n 1)
             mv "dist/$f" "dist/${{ matrix.asset_name }}${{ matrix.ext }}"
-
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.asset_name }}
-          path: packages/thai-romanizer/python/dist/${{ matrix.asset_name }}${{ matrix.ext }}
-          if-no-files-found: error
 
   release:
     name: Attach binaries to Release

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -113,7 +113,7 @@ jobs:
         uses: uraimo/run-on-arch-action@v2
         with:
           arch: aarch64
-          distro: ubuntu24.04
+          distro: ubuntu22.04
           githubToken: ${{ github.token }}
           install: |
             apt-get update

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Build binary
         working-directory: packages/thai-romanizer/python
         run: |
-          pyinstaller --onefile --name "${{matrix.asset_name}}${{ matrix.ext }}" python-thai-romanization.py
+          pyinstaller --name "${{matrix.asset_name}}${{ matrix.ext }}" thai-romanization.spec
           ls -la dist
 
       - name: Upload build artifact

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,63 +1,18 @@
 name: Build Cross-Platform Binaries
 
 on:
-  workflow_run:
-    workflows: ["Tag & Release (after Changesets version)"]
-    types: [completed]
-  release:
-    types: [published]
-  workflow_dispatch:
+  create:
+      tags:
+          - '@romanize-string/thai-romanizer@*'
+  push:
+    tags:
+        - '@romanize-string/thai-romanizer@*'
+  workflow_dispatch: {}
 
 jobs:
-  prepare:
-    name: Determine release tag
-    runs-on: ubuntu-latest
-    outputs:
-      release_tag: ${{ steps.pick.outputs.release_tag }}
-    steps:
-      - name: Pick latest thai-romanizer release tag
-        id: pick
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            const PREFIX = '@romanize-string/thai-romanizer@';
-
-            if (context.eventName === 'release') {
-              const tag = context.payload?.release?.tag_name || '';
-              core.setOutput('release_tag', tag);
-              return;
-            }
-
-            if (context.eventName === 'workflow_run') {
-              const sha = context.payload?.workflow_run?.head_sha;
-              if (!sha) {
-                core.setOutput('release_tag', '');
-                return;
-              }
-              // Find tags that start with our package prefix and point to this SHA
-              const { data: refs } = await github.rest.git.listMatchingRefs({
-                owner,
-                repo,
-                ref: `tags/${PREFIX}`,
-              });
-              const match = refs.find(r => (r.object?.sha === sha));
-              const tag = match ? match.ref.replace('refs/tags/', '') : '';
-              core.setOutput('release_tag', tag);
-              return;
-            }
-
-            // Fallback for manual runs: use the most recent release for the package
-            const { data: releases } = await github.rest.repos.listReleases({ owner, repo, per_page: 50 });
-            const latest = releases.find(r => (r.tag_name || '').startsWith(PREFIX));
-            core.setOutput('release_tag', latest ? latest.tag_name : '');
-
   build:
-    needs: prepare
-    # Only build when we have a thai-romanizer release tag AND either:
-    # - manual run, or
-    # - the upstream workflow completed successfully
-    if: needs.prepare.outputs.release_tag != '' && startsWith(needs.prepare.outputs.release_tag, '@romanize-string/thai-romanizer@') && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' || github.event_name == 'release')
+    # Only build when the tag starts with the correct package prefix or the action is manually triggered
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref_name, '@romanize-string/thai-romanizer@')
     strategy:
       fail-fast: false
       matrix:
@@ -94,7 +49,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ needs.prepare.outputs.release_tag }}
+          ref: ${{ github.ref_name }}
 
       - name: Set up Python (host)
         if: matrix.asset_name != 'thai-linux-arm64'
@@ -153,11 +108,11 @@ jobs:
 
   release:
     name: Attach binaries to Release
-    needs: [build, prepare]
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: startsWith(needs.prepare.outputs.release_tag, '@romanize-string/thai-romanizer@')
+    if: startsWith(github.ref_name, '@romanize-string/thai-romanizer@')
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -176,7 +131,7 @@ jobs:
       - name: Upload assets to release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ needs.prepare.outputs.release_tag }}
+          tag_name: ${{ github.ref_name }}
           overwrite: true
           fail_on_unmatched_files: true
           files: |

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -160,6 +160,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.prepare.outputs.release_tag }}
+          overwrite: true
+          fail_on_unmatched_files: true
           files: |
             artifacts/*/*
-            artifacts/*/*.sha256

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -44,7 +44,7 @@ jobs:
             asset_name: thai-linux-x64
             ext: ''
           # Linux arm64 (ARM runners)
-          - os: ubuntu-24.04-arm64
+          - os: ubuntu-latest
             pyver: '3.11'
             asset_name: thai-linux-arm64
             ext: ''
@@ -72,24 +72,27 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.prepare.outputs.release_tag }}
 
-      - name: Set up Python
+      - name: Set up Python (host)
+        if: matrix.asset_name != 'thai-linux-arm64'
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.pyver }}
 
-      - name: Install dependencies
+      - name: Install dependencies (host)
+        if: matrix.asset_name != 'thai-linux-arm64'
         working-directory: packages/thai-romanizer/python
         run: |
           python -m pip install --upgrade pip
           pip install pyinstaller pythainlp
 
-      - name: Build binary from spec
+      - name: Build binary from spec (host)
+        if: matrix.asset_name != 'thai-linux-arm64'
         working-directory: packages/thai-romanizer/python
         run: |
           pyinstaller thai-romanization.spec
 
       - name: Rename artifact (Windows)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && matrix.asset_name != 'thai-linux-arm64'
         working-directory: packages/thai-romanizer/python
         run: |
           Write-Host "Contents of dist after build:"; Get-ChildItem dist
@@ -97,13 +100,32 @@ jobs:
           Move-Item -Force $file.FullName "dist\${{ matrix.asset_name }}${{ matrix.ext }}"
 
       - name: Rename artifact (Non-Windows)
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && matrix.asset_name != 'thai-linux-arm64'
         shell: bash
         working-directory: packages/thai-romanizer/python
         run: |
           echo "Contents of dist after build:"; ls -la dist
           BUILT_FILE=$(ls -1 dist | head -n 1)
           mv "dist/$BUILT_FILE" "dist/${{ matrix.asset_name }}${{ matrix.ext }}"
+
+      - name: Build arm64 binary in QEMU
+        if: matrix.asset_name == 'thai-linux-arm64'
+        uses: uraimo/run-on-arch-action@v2
+        with:
+          arch: aarch64
+          distro: ubuntu24.04
+          githubToken: ${{ github.token }}
+          install: |
+            apt-get update
+            apt-get install -y python3 python3-pip
+            python3 -m pip install --upgrade pip
+            pip3 install pyinstaller pythainlp
+          run: |
+            cd $GITHUB_WORKSPACE/packages/thai-romanizer/python
+            pyinstaller thai-romanization.spec
+            ls -la dist
+            f=$(ls -1 dist | head -n 1)
+            mv "dist/$f" "dist/${{ matrix.asset_name }}${{ matrix.ext }}"
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tag-and-release-on-version.yml
+++ b/.github/workflows/tag-and-release-on-version.yml
@@ -24,19 +24,16 @@ jobs:
       - name: Determine changed packages
         id: pkgs
         run: |
-          # Find changed package.json files in this push compared to the previous SHA
           CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} \
             | grep -E '^packages/[^/]+/package.json$' || true)
 
-          # Build a JSON array of { name, version, path } for changed packages
-          echo "$CHANGED" | while read -r f; do
+          pkgs=$(echo "$CHANGED" | while read -r f; do
             [ -z "$f" ] && continue
             NAME=$(jq -r '.name' "$f")
             VER=$(jq -r '.version' "$f")
             echo "{\"name\":\"$NAME\",\"version\":\"$VER\",\"path\":\"$f\"}"
-          done | jq -s '.' > /tmp/pkgs.json
-
-          echo "packages=$(cat /tmp/pkgs.json)" >> "$GITHUB_OUTPUT"
+          done | jq -c -s '.')
+          echo "packages=$pkgs" >> "$GITHUB_OUTPUT"
 
       - name: Create tags and releases
         uses: actions/github-script@v7

--- a/.github/workflows/tag-and-release-on-version.yml
+++ b/.github/workflows/tag-and-release-on-version.yml
@@ -2,29 +2,55 @@ name: Tag & Release (after Changesets version)
 
 on:
   push:
-    branches: 
-      - release
+    branches: [release]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref (branch, tag, or SHA) to run against'
+        required: false
+      base:
+        description: 'Base commit/branch/SHA for diff'
+        required: false
+      head:
+        description: 'Head commit/branch/SHA for diff (defaults to ref/sha)'
+        required: false
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   tag_and_release:
-    # Only run when the merge commit contains "Version Packages"
-    if: contains(github.event.head_commit.message, 'Version Packages')
+    # Run on manual triggers OR on "Version Packages" commits to release
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, 'Version Packages')
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # needed to create tags & releases
+      contents: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Determine changed packages
         id: pkgs
+        env:
+          BASE: ${{ inputs.base || github.event.before }}
+          HEAD: ${{ inputs.head || github.sha }}
         run: |
-          CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} \
+          BASE_SHA="${BASE:-}"
+          HEAD_SHA="${HEAD:-}"
+
+          # Fallbacks for manual runs if base not provided
+          if [ -z "$HEAD_SHA" ]; then
+            HEAD_SHA="$(git rev-parse HEAD)"
+          fi
+          if [ -z "$BASE_SHA" ]; then
+            # Default to previous commit on the checked-out ref
+            BASE_SHA="$(git rev-parse "${HEAD_SHA}^" || true)"
+          fi
+
+          CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" \
             | grep -E '^packages/[^/]+/package.json$' || true)
 
           pkgs=$(echo "$CHANGED" | while read -r f; do

--- a/packages/romanize-string/README.md
+++ b/packages/romanize-string/README.md
@@ -3,7 +3,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/romanize-string.svg?style=flat)](https://www.npmjs.com/package/romanize-string) [![NPM monthly downloads](https://img.shields.io/npm/dm/romanize-string.svg?style=flat)](https://npmjs.org/package/romanize-string) [![NPM total downloads](https://img.shields.io/npm/dt/romanize-string.svg?style=flat)](https://npmjs.org/package/romanize-string)
 
-> See the [Changelog](./CHANGELOG.md) for details on recent updates.
+> See the [Changelog](https://github.com/rejyoung/romanize-string/blob/main/packages/romanize-string/CHANGELOG.md) for details on recent updates.
 
 ## Table of Contents
 

--- a/packages/romanize-string/README.md
+++ b/packages/romanize-string/README.md
@@ -3,6 +3,8 @@
 
 [![NPM version](https://img.shields.io/npm/v/romanize-string.svg?style=flat)](https://www.npmjs.com/package/romanize-string) [![NPM monthly downloads](https://img.shields.io/npm/dm/romanize-string.svg?style=flat)](https://npmjs.org/package/romanize-string) [![NPM total downloads](https://img.shields.io/npm/dt/romanize-string.svg?style=flat)](https://npmjs.org/package/romanize-string)
 
+> See the [Changelog](./CHANGELOG.md) for details on recent updates.
+
 ## Table of Contents
 
 - [Introduction](#introduction)

--- a/packages/romanize-string/package.json
+++ b/packages/romanize-string/package.json
@@ -68,12 +68,18 @@
         "@types/node": "^22.16.5",
         "npm-run-all2": "^8.0.4",
         "typescript": "^5.8.3",
-        "vitest": "^3.2.4"
+        "vitest": "^3.2.4",
+        "@romanize-string/thai-romanizer": "workspace:^"
     },
     "peerDependencies": {
-        "@romanize-string/thai-romanizer": "workspace:>=1.0.0 <2.0.0"
-    },
-    "optionalDependencies": {
         "@romanize-string/thai-romanizer": ">=1.0.0 <2.0.0"
+    },
+    "peerDependenciesMeta": {
+        "@romanize-string/thai-romanizer": {
+            "optional": true
+        }
+    },
+    "engines": {
+        "node": ">=16"
     }
 }

--- a/packages/romanize-string/package.json
+++ b/packages/romanize-string/package.json
@@ -68,16 +68,10 @@
         "@types/node": "^22.16.5",
         "npm-run-all2": "^8.0.4",
         "typescript": "^5.8.3",
-        "vitest": "^3.2.4",
-        "@romanize-string/thai-romanizer": "workspace:^"
+        "vitest": "^3.2.4"
     },
-    "peerDependencies": {
+    "optionalPeerDependencies": {
         "@romanize-string/thai-romanizer": ">=1.0.0 <2.0.0"
-    },
-    "peerDependenciesMeta": {
-        "@romanize-string/thai-romanizer": {
-            "optional": true
-        }
     },
     "engines": {
         "node": ">=16"

--- a/packages/thai-romanizer/README.md
+++ b/packages/thai-romanizer/README.md
@@ -3,7 +3,7 @@
 
 Thai-romanizer is a Node-only Thai romanization plugin for [`romanize-string`](https://www.npmjs.com/package/romanize-string). It runs a platform-specific binary (~50 MB) to romanize Thai script using the Python library [PyThaiNLP](https://pypi.org/project/pythainlp/).
 
-> See the [Changelog](./CHANGELOG.md) for details on recent updates.
+> See the [Changelog](https://github.com/rejyoung/romanize-string/blob/main/packages/thai-romanizer/CHANGELOG.md) for details on recent updates.
 
 ## Features
 

--- a/packages/thai-romanizer/README.md
+++ b/packages/thai-romanizer/README.md
@@ -3,6 +3,8 @@
 
 Thai-romanizer is a Node-only Thai romanization plugin for [`romanize-string`](https://www.npmjs.com/package/romanize-string). It runs a platform-specific binary (~50 MB) to romanize Thai script using the Python library [PyThaiNLP](https://pypi.org/project/pythainlp/).
 
+> See the [Changelog](./CHANGELOG.md) for details on recent updates.
+
 ## Features
 
 - Works with romanize-string's plugin system.

--- a/packages/thai-romanizer/package.json
+++ b/packages/thai-romanizer/package.json
@@ -12,7 +12,8 @@
         "@types/node": "^22.16.5",
         "npm-run-all2": "^8.0.4",
         "typescript": "^5.8.3",
-        "romanize-string": "workspace:>=1.3.0 <2.0.0"
+        "romanize-string": "workspace:^",
+        "vitest": "^3.2.4"
     },
     "peerDependencies": {
         "romanize-string": ">=1.3.0 <2.0.0"
@@ -56,7 +57,10 @@
     },
     "license": "MIT",
     "type": "module",
-    "dependencies": {
-        "vitest": "^3.2.4"
+    "engines": {
+        "node": ">=18"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,10 +56,6 @@ importers:
         version: 3.2.4(@types/node@22.17.2)
 
   packages/thai-romanizer:
-    dependencies:
-      vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.17.2)
     devDependencies:
       '@types/node':
         specifier: ^22.16.5
@@ -68,11 +64,14 @@ importers:
         specifier: ^8.0.4
         version: 8.0.4
       romanize-string:
-        specifier: workspace:>=1.2.0 <2.0.0
+        specifier: workspace:^
         version: link:../romanize-string
       typescript:
         specifier: ^5.8.3
         version: 5.9.2
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.17.2)
 
 packages:
 


### PR DESCRIPTION
- Modify Tag & Release (after Changesets version) GitHub action to correctly tag and release versions upon version package merge
- Modify Build Cross-Platform Binaries Github action to correctly build and attach binaries to @romanize-string/thai-romanizer releases whenever a new tag for that package is created